### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ git clone https://gitlab.com/winlinvip/srs-gitlab.git
 
 <pre>
 git clone https://github.com/simple-rtmp-server/srs &&
-cd simple-rtmp-server/trunk
+cd srs/trunk
 </pre>
 
 <strong>Step 2:</strong> build SRS,


### PR DESCRIPTION
Correct path in installation instructions since project repository renamed to srs from simple-rtmp-server

It's easy enough for everyone to see on their own, but for ease of copy-and-paste installation, it's still worth updating.