### PR TITLE
为research/players/srs_player 考虑静态资源部署到单独域名的情况

### DIFF
--- a/trunk/research/players/js/srs.player.js
+++ b/trunk/research/players/js/srs.player.js
@@ -25,6 +25,7 @@ function SrsPlayer(container, width, height, private_object) {
     this.buffer_time = 0.3; // default to 0.3
     this.volume = 1.0; // default to 100%
     this.callbackObj = null;
+    this.srs_player_url = "srs_player/release/srs_player.swf?_version="+srs_get_version_code();
     
     // callback set the following values.
     this.meatadata = {}; // for on_player_metadata
@@ -88,7 +89,7 @@ SrsPlayer.prototype.start = function(url) {
     var self = this;
     
     swfobject.embedSWF(
-        "srs_player/release/srs_player.swf?_version="+srs_get_version_code(), 
+        this.srs_player_url, 
         this.container,
         this.width, this.height,
         "11.1.0", "js/AdobeFlashPlayerInstall.swf",
@@ -182,6 +183,25 @@ SrsPlayer.prototype.set_fs = function(refer, percent) {
 SrsPlayer.prototype.set_bt = function(buffer_time) {
     this.buffer_time = buffer_time;
     this.callbackObj.ref.__set_bt(buffer_time);
+}
+/**
+ * set the srs_player.swf url
+ * @param url, srs_player.swf's url.
+ * @param params, object.
+ */
+ SrsPlayer.prototype.set_srs_player_url = function(url, params) {
+    var query_array = [], 
+        query_string = "", 
+        p;
+    params = params || {}; 
+    params._version = srs_get_version_code();
+    for (p in params) {
+        if (params.hasOwnProperty(p)) {
+            query_array.push(p + "=" + encodeURIComponent(params[p]));
+        }
+    }   
+    query_string = query_array.join("&");
+    this.srs_player_url = url + "?" + query_string;
 }
 SrsPlayer.prototype.on_player_ready = function() {
 }

--- a/trunk/research/players/srs_player/src/srs_player.as
+++ b/trunk/research/players/srs_player/src/srs_player.as
@@ -79,6 +79,8 @@ package
             
             this.stage.addEventListener(FullScreenEvent.FULL_SCREEN, this.user_on_stage_fullscreen);
             
+            Security.allowDomain("*");
+            
             this.addChild(this.control_fs_mask);
             this.control_fs_mask.buttonMode = true;
             this.control_fs_mask.addEventListener(MouseEvent.CLICK, user_on_click_video);


### PR DESCRIPTION
在我们的项目中，srs_player.swf 与js,css等静态资源被部署到单独的域名下。

这触发了两个问题
1. srs.player.js 引用的是swf的相对地址，无法找到。
2. srs_player.swf 与js的交互需要允许跨域。

对于(1)，在js中SrsPlayer对象添加了set_srs_player_url()方法。
对于(2)，在as中添加了跨域许可。