### PR TITLE
fix bug for build failure when configure with --log-info

### DIFF
--- a/trunk/src/kernel/srs_kernel_stream.cpp
+++ b/trunk/src/kernel/srs_kernel_stream.cpp
@@ -60,7 +60,7 @@ int SrsStream::initialize(char* b, int nb)
 
     nb_bytes = nb;
     p = bytes = b;
-    srs_info("init stream ok, size=%d", size);
+    srs_info("init stream ok, size=%d", size());
 
     return ret;
 }


### PR DESCRIPTION
wrong use of size in SrsStream::initialize of  srs_kernel_stream.cpp